### PR TITLE
Add feature to prevent loading the default stylesheet entirely

### DIFF
--- a/Classes/Controller/MainController.php
+++ b/Classes/Controller/MainController.php
@@ -49,11 +49,13 @@ class MainController extends ActionController
 
         $style = $css . '-' . $position;
 
-        $this->response->addAdditionalHeaderData(
-            '<link rel="stylesheet" type="text/css" media="all"  href="' .
-            GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') .
-            '/typo3conf/ext/mindshape_cookie_hint/Resources/Public/Css/' . $style . '.css" />'
-        );
+        if ( $this->settings['doNotLoadCss'] != 1 ) {
+            $this->response->addAdditionalHeaderData(
+                '<link rel="stylesheet" type="text/css" media="all"  href="' .
+                GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') .
+                '/typo3conf/ext/mindshape_cookie_hint/Resources/Public/Css/' . $style . '.css" />'
+            );
+        }
 
         $this->view->assign('style', $style);
     }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -9,6 +9,7 @@ plugin.tx_mindshapecookiehint {
     style = dark
     position = bottom
     appendToBottom = 0
+    doNotLoadCss = 0
   }
 }
 

--- a/Documentation/ExtMindshapeCookieHint/Configuration/ExampleTyposcriptSetup/Index.rst
+++ b/Documentation/ExtMindshapeCookieHint/Configuration/ExampleTyposcriptSetup/Index.rst
@@ -42,6 +42,9 @@ The following example shows all usable settings for the extension:
 		readmore = 35
 		#append the cookie to the bottom of your page so it doesn't overlap footer-content
 		appendToBottom = 0
+		#do not load the included css stylesheet
+		#if activated (doNotLoadCss = 1) you have to add the needed styles in your theme
+		doNotLoadCss = 0
 	  }
 	  
 	  _LOCAL_LANG.de {


### PR DESCRIPTION
Sometimes it is not wanted, that the extension adds their own stylesheet.
Using the proposed feature, the stylesheet from the extension can be disabled.